### PR TITLE
Fixes missing pillars under roads when using Undo

### DIFF
--- a/MoveIt/Moveable.cs
+++ b/MoveIt/Moveable.cs
@@ -307,6 +307,7 @@ namespace MoveIt
                             subBuilding.id.Building = building;
                             subBuilding.m_startPosition = buildingBuffer[building].m_position;
                             subBuilding.m_startAngle = buildingBuffer[building].m_angle;
+                            subBuilding.m_flags = (int)buildingBuffer[building].m_flags;
                             subInstances.Add(subBuilding);
                         }
 


### PR DESCRIPTION
Pillars under roads would disappear when changing road height and then use Undo or Redo.
Missed variable in 1.7.0 commit.